### PR TITLE
DEV-1337: Set customer order reference value

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tonder-web-sdk",
-  "version": "1.15.1",
+  "version": "1.15.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "tonder-web-sdk",
-      "version": "1.15.1",
+      "version": "1.15.2",
       "license": "ISC",
       "dependencies": {
         "crypto-js": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tonder-web-sdk",
-  "version": "1.15.1",
+  "version": "1.15.2",
   "description": "tonder sdk for integrations",
   "main": "src/index.js",
   "scripts": {

--- a/src/classes/BaseInlineCheckout.js
+++ b/src/classes/BaseInlineCheckout.js
@@ -160,6 +160,7 @@ export class BaseInlineCheckout {
         amount: total,
         date: dateString,
         order_id: jsonResponseOrder.id,
+        customer_order_reference: this.order_reference ? this.order_reference : reference,
       };
       const jsonResponsePayment = await createPayment(
         this.baseUrl,
@@ -273,6 +274,7 @@ export class BaseInlineCheckout {
 
   #handleMetadata(data) {
     this.metadata = data?.metadata;
+    this.order_reference = data?.order_reference;
   }
 
   #handleCurrency(data) {

--- a/src/index-dev.js
+++ b/src/index-dev.js
@@ -98,6 +98,8 @@ const checkoutData = {
   // metadata: {
   //   order_id: 123456
   // }
+  // Reference from the merchant
+  order_reference: "ORD-123456"
 };
 
 // localhost


### PR DESCRIPTION
This pull request includes several updates to the `tonder-web-sdk` package, primarily focusing on adding support for an `order_reference` in the `BaseInlineCheckout` class and updating the package version.

### Version Update:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the package version from `1.15.1` to `1.15.2`.

### Enhancements to `BaseInlineCheckout` class:
* [`src/classes/BaseInlineCheckout.js`](diffhunk://#diff-b8ef63bbc0464ea7cec1eae0528c4796c606baceaaacaf730cebc0d6f2b68226R163): Added a `customer_order_reference` field to the order details.
* [`src/classes/BaseInlineCheckout.js`](diffhunk://#diff-b8ef63bbc0464ea7cec1eae0528c4796c606baceaaacaf730cebc0d6f2b68226R277): Introduced a new property `order_reference` in the `#handleMetadata` method.

### Example Data Update:
* [`src/index-dev.js`](diffhunk://#diff-712b27c6827fb15c683bc1c266b7ae9c918c57c74755a6ec61b6bd44c37baaf3R101-R102): Added an `order_reference` example in the `checkoutData` object.