### PR TITLE
DEV-1599:  Fix clearing cached verify url for pending transactions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tonder-web-sdk",
-  "version": "1.16.10",
+  "version": "1.16.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "tonder-web-sdk",
-      "version": "1.16.10",
+      "version": "1.16.11",
       "license": "ISC",
       "dependencies": {
         "accordion-js": "^3.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tonder-web-sdk",
-  "version": "1.16.10",
+  "version": "1.16.11",
   "description": "tonder sdk for integrations",
   "scripts": {
     "start": "webpack-dev-server",

--- a/src/classes/3dsHandler.js
+++ b/src/classes/3dsHandler.js
@@ -114,15 +114,9 @@ export class ThreeDSHandler {
     return parameters;
   }
 
-  // TODO: Remove this duplication
-  handleSuccessTransaction(response) {
+  handleCompletedTransaction(response) {
     this.removeVerifyTransactionUrl();
-    console.log("Transacción autorizada");
-    return response;
-  }
-
-  handleDeclinedTransaction(response) {
-    this.removeVerifyTransactionUrl();
+    console.log("Transacción completada");
     return response;
   }
 
@@ -159,10 +153,13 @@ export class ThreeDSHandler {
     // Azul property
     if (response_json.status === "Pending" && response_json.redirect_post_url) {
       return await this.handle3dsChallenge(response_json);
-    } else if (["Success", "Authorized"].includes(response_json.status)) {
-      return this.handleSuccessTransaction(response_json);
-    } else {
-      this.handleDeclinedTransaction();
+    } else if (["Success", "Authorized", "Declined"].includes(response_json.status)) {
+      return this.handleCompletedTransaction(response_json);
+    } else if (
+      response_json.transaction_status === "Pending" ||
+      response_json.status === "Pending"
+    ) {
+      // Don't remove URL for pending transactions to allow polling
       return response_json;
     }
   }


### PR DESCRIPTION
This pull request includes a version bump for the `tonder-web-sdk` and refactors the `ThreeDSHandler` class to consolidate transaction handling logic, reducing duplication and improving maintainability.

### Version Update:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the version from `1.16.10` to `1.16.11` to reflect the changes in the SDK.

### Refactoring of `ThreeDSHandler`:
* [`src/classes/3dsHandler.js`](diffhunk://#diff-5f05626e9173ed1b4995140618791ae23168f0855bd92316a805d0bb27c551a2L117-R119): Replaced the `handleSuccessTransaction` and `handleDeclinedTransaction` methods with a unified `handleCompletedTransaction` method, reducing duplicated code.
* [`src/classes/3dsHandler.js`](diffhunk://#diff-5f05626e9173ed1b4995140618791ae23168f0855bd92316a805d0bb27c551a2L162-R162): Updated the transaction handling logic to use the new `handleCompletedTransaction` method and added a condition to avoid removing the URL for pending transactions, ensuring proper handling of polling scenarios.